### PR TITLE
Fix top blocks not being sampled

### DIFF
--- a/src/main/java/caeruleusTait/world/preview/backend/worker/HeightmapWorkUnit.java
+++ b/src/main/java/caeruleusTait/world/preview/backend/worker/HeightmapWorkUnit.java
@@ -53,7 +53,7 @@ public class HeightmapWorkUnit extends WorkUnit {
         final int minY = config.onlySampleInVisualRange ? config.heightmapMinY : noiseSettings.minY();
         final int maxY = config.onlySampleInVisualRange ? config.heightmapMaxY : minY + noiseSettings.height();
         final int cellMinY = Mth.floorDiv(minY, noiseSettings.getCellHeight());
-        final int cellCountY = Mth.floorDiv(maxY - minY, noiseSettings.getCellHeight());
+        final int cellCountY = -Mth.floorDiv(minY - maxY, noiseSettings.getCellHeight());
         final int cellOffsetY = config.onlySampleInVisualRange ? cellMinY -  Mth.floorDiv(noiseSettings.minY(), noiseSettings.getCellHeight()): 0;
 
         final int minBlockX = chunkPos.getMinBlockX();
@@ -91,6 +91,7 @@ public class HeightmapWorkUnit extends WorkUnit {
                         // Iterate over block in cell Y X Z
                         for (int yInCell = cellHeight - 1; yInCell >= 0 && !positions.isEmpty(); --yInCell) {
                             final int y = (cellMinY + cellY) * cellHeight + yInCell;
+                            if (y >= maxY) continue;
                             noiseChunk.updateForY(y, (double) yInCell / (double) cellHeight);
 
                             for (int idx = 0; idx < positions.size(); ++idx) {


### PR DESCRIPTION
This bug occurs due to `cellHeight`. At line 56 in `HeightmapWorkUnit.java`, depending on the values of the "Higher y-value" heightmap setting and `cellHeight`, the resulting value can undershoot the "Higher y-value" heightmap setting, so the highest y-value allowed isn't actually sampled. With this fix, instead of sometimes undershooting, it will now sometimes overshoot, which is okay because of the added `if (y >= maxY) continue;` line, which stops those overshot values from being sampled.

For the screenshots below, in the heightmap settings I have "Higher y-value" set to 300. Without the fix, this position shows 296, despite in reality being over 300 blocks high. With the fix, it correctly shows 300.

Before:

<img width="475" height="331" alt="Untitled" src="https://github.com/user-attachments/assets/1b9e565a-41f9-4335-a838-7f29e17cc950" />

After:

<img width="484" height="324" alt="Untitled2" src="https://github.com/user-attachments/assets/d8571d84-069f-46dc-85be-398463801f92" />
